### PR TITLE
Fix for memdump loop

### DIFF
--- a/examples/mifareclassic_memdump/mifareclassic_memdump.pde
+++ b/examples/mifareclassic_memdump/mifareclassic_memdump.pde
@@ -198,5 +198,8 @@ void loop(void) {
   Serial.println("\n\nSend a character to run the mem dumper again!");
   Serial.flush();
   while (!Serial.available());
+  while (Serial.available()) {
+	Serial.read();
+  }
   Serial.flush();
 }


### PR DESCRIPTION
The wait for Serial input at the end of loop() was not clearing the Serial buffer so after entering something once the code would move into an infinite loop, dumping the card data over and over. This makes it to where inputting data to the serial will only trigger the loop once, making reading multiple cards much easier.
