### PR TITLE
Writing data in "readMifare" example not correctly implemented

### DIFF
--- a/examples/readMifare/readMifare.pde
+++ b/examples/readMifare/readMifare.pde
@@ -2,7 +2,7 @@
 /*! 
     @file     readMifare.pde
     @author   Adafruit Industries
-	@license  BSD (see license.txt)
+    @license  BSD (see license.txt)
 
     This example will wait for any ISO14443A card or tag, and
     depending on the size of the UID will attempt to read from it.
@@ -14,7 +14,7 @@
       the default KEYA of 0XFF 0XFF 0XFF 0XFF 0XFF 0XFF
     - If authentication succeeds, we can then read any of the
       4 blocks in that sector (though only block 4 is read here)
-	 
+   
     If the card has a 7-byte UID it is probably a Mifare
     Ultralight card, and the 4 byte pages can be read directly.
     Page 4 is read by default since this is the first 'general-
@@ -86,37 +86,37 @@ void loop(void) {
     {
       // We probably have a Mifare Classic card ... 
       Serial.println("Seems to be a Mifare Classic card (4 byte UID)");
-	  
+    
       // Now we need to try to authenticate it for read/write access
       // Try with the factory default KeyA: 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF
       Serial.println("Trying to authenticate block 4 with default KEYA value");
       uint8_t keya[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-	  
-	  // Start with block 4 (the first block of sector 1) since sector 0
-	  // contains the manufacturer data and it's probably better just
-	  // to leave it alone unless you know what you're doing
+    
+      // Start with block 4 (the first block of sector 1) since sector 0
+      // contains the manufacturer data and it's probably better just
+      // to leave it alone unless you know what you're doing
       success = nfc.mifareclassic_AuthenticateBlock(uid, uidLength, 4, 0, keya);
-	  
+    
       if (success)
       {
         Serial.println("Sector 1 (Blocks 4..7) has been authenticated");
         uint8_t data[16];
-		
+    
         // If you want to write something to block 4 to test with, uncomment
-		// the following line and this text should be read back in a minute
+        // the following line and this text should be read back in a minute
         //memcpy(data, (const uint8_t[]){ 'a', 'd', 'a', 'f', 'r', 'u', 'i', 't', '.', 'c', 'o', 'm', 0, 0, 0, 0 }, sizeof data);
         //success = nfc.mifareclassic_WriteDataBlock (4, data);
 
         // Try to read the contents of block 4
         success = nfc.mifareclassic_ReadDataBlock(4, data);
-		
+    
         if (success)
         {
           // Data seems to have been read ... spit it out
           Serial.println("Reading Block 4:");
           nfc.PrintHexChar(data, 16);
           Serial.println("");
-		  
+      
           // Wait a bit before reading the card again
           delay(1000);
         }
@@ -135,7 +135,7 @@ void loop(void) {
     {
       // We probably have a Mifare Ultralight card ...
       Serial.println("Seems to be a Mifare Ultralight tag (7 byte UID)");
-	  
+    
       // Try to read the first general-purpose user page (#4)
       Serial.println("Reading page 4");
       uint8_t data[32];
@@ -145,7 +145,7 @@ void loop(void) {
         // Data seems to have been read ... spit it out
         nfc.PrintHexChar(data, 4);
         Serial.println("");
-		
+    
         // Wait a bit before reading the card again
         delay(1000);
       }


### PR DESCRIPTION
In the "readMifare"-example you can uncomment the lines 107 and 108 to write "adafruit.com" to sector 4 as a test. Uncommenting the lines causes the following compiler error

```
readMifare.pde: In function 'void loop()':
readMifare:107: error: expected primary-expression before '{' token
readMifare:107: error: expected `;' before '{' token
```

with the reason being that you cannot assign an array after declaration.
To fix that, you can use `memcpy` to fill the data-array:

``` c
memcpy(data, (const uint8_t[]){ 'a', 'd', 'a', 'f', 'r', 'u', 'i', 't', '.', 'c', 'o', 'm', 0, 0, 0, 0 }, sizeof data);
```

Furthermore, I have cleaned up the indentation to be two spaces all the way through, some comments were indented using tabs.
