### PR TITLE
Corrected a call to print hex chars in a debug statement

### DIFF
--- a/Adafruit_NFCShield_I2C.cpp
+++ b/Adafruit_NFCShield_I2C.cpp
@@ -611,7 +611,7 @@ uint8_t Adafruit_NFCShield_I2C::mifareclassic_AuthenticateBlock (uint8_t * uid, 
   {
     #ifdef PN532DEBUG
     Serial.print("Authentification failed: ");
-    Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 12);
+    Adafruit_NFCShield_I2C::PrintHexChar(pn532_packetbuffer, 12);
     #endif
     return 0;
   }  


### PR DESCRIPTION
In `Adafruit_NFCShield_I2C::mifareclassic_AuthenticateBlock`, the debug block was calling `Adafruit_PN532::PrintHexChar` instead of the correct `Adafruit_NFCShield_I2C::PrintHexChar`
